### PR TITLE
Add python script overlay for signac job info

### DIFF
--- a/signac/overlay_signac_statepoint.py
+++ b/signac/overlay_signac_statepoint.py
@@ -1,0 +1,67 @@
+import numpy as np
+import os
+import PySide6
+import signac
+
+
+def render(args, alpha=95):
+    """Render information from a job's document and/or statepoint.
+
+    Args:
+        alpha (float): Opacity of textbox, in percent. 100 = fully opaque.
+    """
+    pipeline = args.scene.selected_pipeline
+    window_height = args.size[1]
+    
+    if pipeline:
+        data = pipeline.compute(args.frame)
+        source_file = data.attributes['SourceFile']
+        dirname = os.path.dirname(source_file)
+        job = signac.get_job(dirname)
+        jobid = job._id[:8]
+        
+        # get data from job statepoint and/or doc and create strings
+        strings = [
+            jobid,
+            f'{job.sp.num_particles} particles',
+            f'param1 = {job.sp.param1}',
+            f'param2 = {job.sp.param2}',
+            f'param3 = {job.doc.param3}',
+            # etc...
+        ]
+        
+        # make fontsize scale with window size
+        font = args.painter.font()
+        fontsize = window_height * 13/500
+        font.setPointSizeF(fontsize)
+        whitespace_buffer = int(window_height / 100)
+        args.painter.setFont(font)
+        horizontal_advance = 0
+        descent = args.painter.fontMetrics().descent()
+        ascent = args.painter.fontMetrics().ascent()
+        
+        # figure out how wide to make the text box
+        for _str in strings:
+            horizontal_advance = max(
+                args.painter.fontMetrics().horizontalAdvance(_str),
+                horizontal_advance,
+            )
+        width = horizontal_advance + fontsize // 3
+
+        # draw textbox
+        x1 = whitespace_buffer
+        y1 = int(whitespace_buffer)
+        height = int(1.3*fontsize*len(strings)-1)
+        args.painter.fillRect(
+            x1, y1, width, height,
+            PySide6.QtGui.QColor(255, 255, 255, int(alpha/100 * 255))
+        )
+        args.painter.drawRect(x1, y1, width, height)  
+      
+        # add text on top of box
+        for i, _str in enumerate(strings):
+            x = args.painter.drawText(
+                fontsize // 6 + whitespace_buffer,
+                int(0.75 * fontsize + whitespace_buffer + 1.3*fontsize*i) + fontsize // 6,
+                _str,
+            )

--- a/signac/overlay_signac_statepoint.py
+++ b/signac/overlay_signac_statepoint.py
@@ -2,7 +2,9 @@
 # viewport.
 
 import os
+
 import PySide6
+
 import signac
 
 
@@ -14,33 +16,33 @@ def render(args, alpha=95):
     """
     pipeline = args.scene.selected_pipeline
     window_height = args.size[1]
-    
+
     if pipeline:
         data = pipeline.compute(args.frame)
-        source_file = data.attributes['SourceFile']
+        source_file = data.attributes["SourceFile"]
         dirname = os.path.dirname(source_file)
         job = signac.get_job(dirname)
         jobid = job._id[:8]
-        
+
         # get data from job statepoint and/or doc and create strings
         strings = [
             jobid,
-            f'{job.sp.num_particles} particles',
-            f'param1 = {job.sp.param1}',
-            f'param2 = {job.doc.param2}',
+            f"{job.sp.num_particles} particles",
+            f"param1 = {job.sp.param1}",
+            f"param2 = {job.doc.param2}",
             # etc...
         ]
-        
+
         # make fontsize scale with window size
         font = args.painter.font()
-        fontsize = window_height * 13/500
+        fontsize = window_height * 13 / 500
         font.setPointSizeF(fontsize)
         whitespace_buffer = int(window_height / 100)
         args.painter.setFont(font)
         horizontal_advance = 0
         descent = args.painter.fontMetrics().descent()
         ascent = args.painter.fontMetrics().ascent()
-        
+
         # figure out how wide to make the text box
         for _str in strings:
             horizontal_advance = max(
@@ -52,17 +54,21 @@ def render(args, alpha=95):
         # draw textbox
         x1 = whitespace_buffer
         y1 = int(whitespace_buffer)
-        height = int(1.3*fontsize*len(strings)-1)
+        height = int(1.3 * fontsize * len(strings) - 1)
         args.painter.fillRect(
-            x1, y1, width, height,
-            PySide6.QtGui.QColor(255, 255, 255, int(alpha/100 * 255))
+            x1,
+            y1,
+            width,
+            height,
+            PySide6.QtGui.QColor(255, 255, 255, int(alpha / 100 * 255)),
         )
-        args.painter.drawRect(x1, y1, width, height)  
-      
+        args.painter.drawRect(x1, y1, width, height)
+
         # add text on top of box
         for i, _str in enumerate(strings):
             x = args.painter.drawText(
                 fontsize // 6 + whitespace_buffer,
-                int(0.75 * fontsize + whitespace_buffer + 1.3*fontsize*i) + fontsize // 6,
+                int(0.75 * fontsize + whitespace_buffer + 1.3 * fontsize * i)
+                + fontsize // 6,
                 _str,
             )

--- a/signac/overlay_signac_statepoint.py
+++ b/signac/overlay_signac_statepoint.py
@@ -1,4 +1,6 @@
-import numpy as np
+# Modify the `strings` variable to control what values get rendered in the
+# viewport.
+
 import os
 import PySide6
 import signac
@@ -25,8 +27,7 @@ def render(args, alpha=95):
             jobid,
             f'{job.sp.num_particles} particles',
             f'param1 = {job.sp.param1}',
-            f'param2 = {job.sp.param2}',
-            f'param3 = {job.doc.param3}',
+            f'param2 = {job.doc.param2}',
             # etc...
         ]
         

--- a/signac/overlay_signac_statepoint.py
+++ b/signac/overlay_signac_statepoint.py
@@ -40,8 +40,6 @@ def render(args, alpha=95):
         whitespace_buffer = int(window_height / 100)
         args.painter.setFont(font)
         horizontal_advance = 0
-        descent = args.painter.fontMetrics().descent()
-        ascent = args.painter.fontMetrics().ascent()
 
         # figure out how wide to make the text box
         for _str in strings:
@@ -66,7 +64,7 @@ def render(args, alpha=95):
 
         # add text on top of box
         for i, _str in enumerate(strings):
-            x = args.painter.drawText(
+            args.painter.drawText(
                 fontsize // 6 + whitespace_buffer,
                 int(0.75 * fontsize + whitespace_buffer + 1.3 * fontsize * i)
                 + fontsize // 6,


### PR DESCRIPTION
This PR adds a script to add an overlay to the viewport that renders information from a signac job's statepoint and/or document. It renders the information in a text box with a user-modifiable transparency. The size of the font and text box scale with the window size. I selected the fontsizes and scaling parameters by trial-and-error, and there may be better ways to achieve those goals.