### PR TITLE
Update overlay_RDF.py

### DIFF
--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -1,4 +1,4 @@
-#Copyright (c) 2019 The Regents of the University of Michigan
+# Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -1,4 +1,4 @@
-Copyright (c) 2019 The Regents of the University of Michigan
+#Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The Regents of the University of Michigan
+ Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 
@@ -17,11 +17,11 @@ def render(
     bins: int = 300,
     r_max: float = 5.0,
     dpi: float = 150,
-    width: float = 3.5,
-    height: float = 3,
-    draw_x: float = 10,
+    draw_x: float = 10
+    width:float = None,
+    height:float = None,
     draw_y: float = 10,
-    align: str = "bottom left",
+    align: str = "top right",
 ):
     plt.close()
     pipeline = args.scene.selected_pipeline
@@ -36,6 +36,10 @@ def render(
 
     viewport_width = args.painter.window().width()
     viewport_height = args.painter.window().height()
+    if width is None:
+        width = viewport_width/600
+    if height is None:
+        height = viewport_height/800
     if "right" in align:
         draw_x = viewport_width - dpi * width - draw_x
     if "bottom" in align:
@@ -44,6 +48,7 @@ def render(
     # Create figure
     fig, ax = plt.subplots(figsize=(width, height), dpi=dpi)
     rdf.plot(ax=ax)
+    fig.patch.set_alpha(0.0)
     plt.tight_layout()
 
     # Render figure to an in-memory buffer.

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -22,6 +22,7 @@ def render(
     height: float = None,
     draw_y: float = 10,
     align: str = "bottom left",
+    compute_first_shell_min: bool = False,
 ):
     plt.close()
     pipeline = args.scene.selected_pipeline

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -48,6 +48,17 @@ def render(
     # Create figure
     fig, ax = plt.subplots(figsize=(width, height), dpi=dpi)
     rdf.plot(ax=ax)
+
+    if compute_first_shell_min:
+        import scipy
+        import numpy as np        
+        rdf_minima = scipy.signal.argrelmin(rdf.rdf)[0]
+        min_point = [rdf.bin_centers[rdf_minima[np.argmin(rdf.rdf[rdf_minima])]]]
+        plt.vlines(min_point,*ax.get_ylim(),"k","dashed",label=min_point[0].round(3))    
+        plt.legend()
+        print(f"RDF_MIN: {min_point}")
+        
+    plt.tight_layout()
     fig.patch.set_alpha(0.0)
     plt.tight_layout()
 

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -17,7 +17,7 @@ def render(
     bins: int = 300,
     r_max: float = 5.0,
     dpi: float = 150,
-    draw_x: float = 10
+    draw_x: float = 10,
     width:float = None,
     height:float = None,
     draw_y: float = 10,

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -21,7 +21,7 @@ def render(
     width:float = None,
     height:float = None,
     draw_y: float = 10,
-    align: str = "top right",
+    align: str = "bottom left",
 ):
     plt.close()
     pipeline = args.scene.selected_pipeline

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -18,8 +18,8 @@ def render(
     r_max: float = 5.0,
     dpi: float = 150,
     draw_x: float = 10,
-    width:float = None,
-    height:float = None,
+    width: float = None,
+    height: float = None,
     draw_y: float = 10,
     align: str = "bottom left",
 ):
@@ -37,9 +37,9 @@ def render(
     viewport_width = args.painter.window().width()
     viewport_height = args.painter.window().height()
     if width is None:
-        width = viewport_width/600
+        width = viewport_width / 600
     if height is None:
-        height = viewport_height/800
+        height = viewport_height / 800
     if "right" in align:
         draw_x = viewport_width - dpi * width - draw_x
     if "bottom" in align:
@@ -52,9 +52,12 @@ def render(
     if compute_first_shell_min:
         import numpy as np
         import scipy
+
         rdf_minima = scipy.signal.argrelmin(rdf.rdf)[0]
         min_point = [rdf.bin_centers[rdf_minima[np.argmin(rdf.rdf[rdf_minima])]]]
-        plt.vlines(min_point,*ax.get_ylim(),"k","dashed",label=min_point[0].round(3))
+        plt.vlines(
+            min_point, *ax.get_ylim(), "k", "dashed", label=min_point[0].round(3)
+        )
         plt.legend()
         print(f"RDF_MIN: {min_point}")
 

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -50,14 +50,14 @@ def render(
     rdf.plot(ax=ax)
 
     if compute_first_shell_min:
+        import numpy as np
         import scipy
-        import numpy as np        
         rdf_minima = scipy.signal.argrelmin(rdf.rdf)[0]
         min_point = [rdf.bin_centers[rdf_minima[np.argmin(rdf.rdf[rdf_minima])]]]
-        plt.vlines(min_point,*ax.get_ylim(),"k","dashed",label=min_point[0].round(3))    
+        plt.vlines(min_point,*ax.get_ylim(),"k","dashed",label=min_point[0].round(3))
         plt.legend()
         print(f"RDF_MIN: {min_point}")
-        
+
     plt.tight_layout()
     fig.patch.set_alpha(0.0)
     plt.tight_layout()

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -1,4 +1,4 @@
- Copyright (c) 2019 The Regents of the University of Michigan
+Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 


### PR DESCRIPTION
overlay_RDF.py has been updated to automatically select a width and height based on the DPI of the view. The original width and height parameters still work to override this code. In addition, the figure axes have been set to transparent to allow for more compact layouts. 

An optional toggle has been added that computes the first well minimum radius. Note that this is based off of `np.argmin`, so it actually finds the well with the minimum value - not necessarily the first well. 