### PR TITLE
Update overlay_BondOrder.py

### DIFF
--- a/freud/overlay_BondOrder.py
+++ b/freud/overlay_BondOrder.py
@@ -1,16 +1,11 @@
 # Copyright (c) 2021 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-
 from typing import Tuple
-
 import numpy as np
 import PySide6.QtGui
 import rowan
-
 import freud
-
-
 def to_view(bod, view_orientation, image_size):
     lin_grid = np.linspace(-1, 1, image_size)
     x, y = np.meshgrid(lin_grid, lin_grid)
@@ -30,31 +25,35 @@ def to_view(bod, view_orientation, image_size):
     view = bod.bond_order[theta_bins, phi_bins]
     view[r2 > 1] = np.nan
     return view
+    
 
-
-def to_image(arr, cmap="afmhot", vmin=0, vmax=None):
+def to_image(arr, cmap="afmhot", vmin=0, vmax=None,clip_percentile=0.6,viewmode="percentile"):
     import matplotlib.cm
     import matplotlib.colors
-
     if vmax is None:
-        vmax = np.nanmax(arr)
+        
+        if viewmode == "percentile":
+            vmax = np.nanpercentile(arr,clip_percentile)
+        else:
+            vmax = np.nanmax(arr)*0.6
     norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax, clip=True)
     cmap = matplotlib.cm.get_cmap(cmap)
     image = cmap(norm(arr))
     return (image * 255).astype(np.uint8)
-
-
+    
 def render(
     args,
     bins: Tuple[int] = (200, 200),
     mode: str = "bod",
     neighbors: dict = {"r_max": 1.4},
-    image_size: int = 200,
-    draw_x: float = 10,
-    draw_y: float = 10,
+    image_size:float = None,
+    draw_x:int = None,
+    draw_y:int = None,
+    clip_percentile:float = 99.9,
+    viewmode:str = "percentile",
+    n_frames_to_average:int = 10
 ):
     """Render a bond order diagram that rotates with the view.
-
     Args:
         args:
             OVITO viewport modifier arguments.
@@ -74,17 +73,32 @@ def render(
             X coordinate of the top-left corner of the drawn image.
         draw_y:
             Y coordinate of the top-left corner of the drawn image.
-
+        clip_percentile:
+            Percentile at which to clip data from the BOD. Default value = 99.9.
+        viewmode:
+            Whether to clip values based on percentile (recommended), or fall back to the old style of 0.6*max(bod). 
+            Any value other than "percentile" will use the old clipping method.
+            Default value: "percentile"
     """
+    if image_size is None:
+        image_size = args.size[1] // 4
+    if draw_x is None:
+        draw_x = args.size[1] - 10 - image_size
+    if draw_y is None:
+        draw_y = args.size[0] - 10 - image_size
+    
+    
     pipeline = args.scene.selected_pipeline
     if not pipeline:
         return
-    data = pipeline.compute(args.frame)
+
     view_orientation = rowan.from_matrix(args.viewport.viewMatrix[:, :3])
     bod = freud.environment.BondOrder(bins, mode)
-    bod.compute(system=data, neighbors=neighbors)
+    data = pipeline.compute(args.frame)
+    bod.compute(system=data, neighbors=neighbors,orientations=data.particles.orientations,reset=True)
+        
     view = to_view(bod, view_orientation, image_size)
-    buf = to_image(view, cmap="afmhot")
+    buf = to_image(view, cmap="afmhot",clip_percentile=clip_percentile,viewmode=viewmode)
     width, height, bytes_per_pixel = buf.shape
     img = PySide6.QtGui.QImage(
         buf,


### PR DESCRIPTION
BOD code has been updated to clip values based on percentiles, rather than a fraction of the maximum value. This yields more predictable clipping behavior and cleaner plots. In addition, the code selects a "good" plot size by default. Both of these options can fall back to the original behavior by setting the appropriate values.