### PR TITLE
Establish pattern for overlays in Ovito 3.11+

### DIFF
--- a/cmaps/cubeellipse/cubeellipse.py
+++ b/cmaps/cubeellipse/cubeellipse.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+
 import numpy as np
 import numpy.linalg as la
 

--- a/freud/modifier_Cluster.py
+++ b/freud/modifier_Cluster.py
@@ -2,9 +2,8 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 
-import numpy as np
-
 import freud
+import numpy as np
 
 
 def modify(frame, data):

--- a/freud/modifier_Hexatic.py
+++ b/freud/modifier_Hexatic.py
@@ -2,9 +2,8 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 
-import numpy as np
-
 import freud
+import numpy as np
 
 
 def modify(frame, data):

--- a/freud/modifier_Nematic.py
+++ b/freud/modifier_Nematic.py
@@ -2,9 +2,8 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 
-import numpy as np
-
 import freud
+import numpy as np
 
 
 def modify(frame, data):

--- a/freud/modifier_add_noise.py
+++ b/freud/modifier_add_noise.py
@@ -4,9 +4,8 @@
 
 # Keeps a certain particle at the center of the box by shifting and wrapping other particles.
 
-import numpy as np
-
 import freud
+import numpy as np
 
 
 def modify(frame, data, sigma=0.05, wrap=True):

--- a/freud/overlay_BondOrder.py
+++ b/freud/overlay_BondOrder.py
@@ -3,11 +3,11 @@
 # This software is licensed under the BSD 3-Clause License.
 from typing import Tuple
 
-import numpy as np
 import PySide6.QtGui
 import rowan
 
 import freud
+import numpy as np
 
 
 def to_view(bod, view_orientation, image_size):

--- a/freud/overlay_BondOrder.py
+++ b/freud/overlay_BondOrder.py
@@ -1,125 +1,100 @@
 # Copyright (c) 2021 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-from typing import Tuple
 
+import matplotlib.cm
+import matplotlib.colors
 import PySide6.QtGui
-import rowan
+from ovito.data import DataCollection
+from ovito.vis import ViewportOverlayInterface
+from traits.api import Dict, Enum, Range, String, Tuple
 
 import freud
 import numpy as np
 
 
-def to_view(bod, view_orientation, image_size):
+class BondOrderOverlay(ViewportOverlayInterface):
+    # Adjustable user parameters:
+    bins = Tuple((220, 220), label="(θ,φ) Bins", dtype=tuple[int, int])
+    output_size = Range(value=440, low=1, label="Output Image Size", dtype=int)
+
+    neighbors = Dict({"r_max": 1.4}, label="Neighbor Query")
+
+    cmap = String(value="afmhot", label="Colormap")
+
+    clip_percentile = Range(value=99.9, low=0.0, high=100.0, label="Clip Percentile")
+
+    mode = Enum(
+        ["bod", "obcd", "lbod", "oocd"],
+        value="bod",
+        label="BOD Mode",
+    )
+
+    # Code image position to the anchor parameter of canvas.draw_image
+    anchor = Enum(
+        ["south west", "south east", "north west", "north east"],
+        value="south east",
+        label="Image Position",
+    )
+
+    def render(
+        self, canvas: ViewportOverlayInterface.Canvas, data: DataCollection, **kwargs
+    ):
+        bod = freud.environment.BondOrder(bins=self.bins, mode=self.mode)
+        bod.compute(
+            system=data,
+            neighbors=dict(self.neighbors),  # Ovito api 'Dict' to python base version
+            orientations=data.particles.orientations,
+            reset=True,
+        )
+
+        # Conver the BOD to a 2D image with the correct size and view orientation
+        view = to_view(bod, canvas.view_tm[:, :3], image_size=self.output_size)
+
+        vmin, vmax = 0.0, np.nanpercentile(view, self.clip_percentile)
+        norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax, clip=True)
+        cmap = matplotlib.cm.get_cmap(self.cmap)
+        image = cmap(norm(view))
+        buf = (image * 255).astype(np.uint8)
+
+        width, height, bytes_per_pixel = buf.shape
+        img = PySide6.QtGui.QImage(
+            buf, width, height, width * bytes_per_pixel, canvas.preferred_qimage_format
+        )
+
+        size_fraction = self.output_size / np.array(canvas.logical_size)
+        image_pos = (
+            0.01 if "west" in self.anchor else 0.99,
+            0.01 if "south" in self.anchor else 0.99,
+        )
+
+        canvas.draw_image(img, pos=image_pos, size=size_fraction, anchor=self.anchor)
+
+        return
+
+
+def to_view(bod, view_matrix, image_size):
+    """Convert a BOD in spherical coordinates to a hemispherical image on a plane."""
     lin_grid = np.linspace(-1, 1, image_size)
-    x, y = np.meshgrid(lin_grid, lin_grid)
-    y = -y
+    x, y = np.meshgrid(lin_grid, -lin_grid)
     r2 = x**2 + y**2
     z = np.sqrt(np.clip(1 - r2, 0, None))
     xyz = np.dstack((x, y, z))
-    xyz = rowan.rotate(rowan.inverse(view_orientation), xyz)
-    x, y, z = xyz[:, :, 0], xyz[:, :, 1], xyz[:, :, 2]
+
+    xyz = xyz @ view_matrix
+    x, y, z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
+
     view = np.zeros((image_size, image_size))
     phi = np.arccos(z)
     theta = np.arctan2(y, x) % (2 * np.pi)
+
     num_theta_bins, num_phi_bins = bod.nbins
     theta_bin_edges, phi_bin_edges = bod.bin_edges
+
     theta_bins = np.trunc(theta / (2 * np.pi) * num_theta_bins).astype(int)
     phi_bins = np.trunc(phi / np.pi * num_phi_bins).astype(int)
+
     view = bod.bond_order[theta_bins, phi_bins]
     view[r2 > 1] = np.nan
+
     return view
-
-
-def to_image(
-    arr, cmap="afmhot", vmin=0, vmax=None, clip_percentile=0.6, viewmode="percentile"
-):
-    import matplotlib.cm
-    import matplotlib.colors
-
-    if vmax is None:
-        if viewmode == "percentile":
-            vmax = np.nanpercentile(arr, clip_percentile)
-        else:
-            vmax = np.nanmax(arr) * 0.6
-    norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax, clip=True)
-    cmap = matplotlib.cm.get_cmap(cmap)
-    image = cmap(norm(arr))
-    return (image * 255).astype(np.uint8)
-
-
-def render(
-    args,
-    bins: Tuple[int] = (200, 200),
-    mode: str = "bod",
-    neighbors: dict = {"r_max": 1.4},
-    image_size: float = None,
-    draw_x: int = None,
-    draw_y: int = None,
-    clip_percentile: float = 99.9,
-    viewmode: str = "percentile",
-    n_frames_to_average: int = 10,
-):
-    """Render a bond order diagram that rotates with the view.
-    Args:
-        args:
-            OVITO viewport modifier arguments.
-        bins:
-            Passed to freud.environment.BondOrder.
-        mode:
-            Passed to freud.environment.BondOrder.
-        neighbors:
-            Passed to freud.environment.BondOrder.compute. It is recommended
-            to use a cutoff distance at the first trough of the radial
-            distribution function g(r). See
-            https://freud.readthedocs.io/en/latest/topics/querying.html for
-            more information.
-        image_size:
-            Rendered size of the bond order diagram.
-        draw_x:
-            X coordinate of the top-left corner of the drawn image.
-        draw_y:
-            Y coordinate of the top-left corner of the drawn image.
-        clip_percentile:
-            Percentile at which to clip data from the BOD. Default value = 99.9.
-        viewmode:
-            Whether to clip values based on percentile (recommended), or fall back
-            to the old style of 0.6*max(bod). Any value other than "percentile"
-            will use the old clipping method. Default value: "percentile"
-
-    """
-    if image_size is None:
-        image_size = args.size[1] // 4
-    if draw_x is None:
-        draw_x = args.size[1] - 10 - image_size
-    if draw_y is None:
-        draw_y = args.size[0] - 10 - image_size
-
-    pipeline = args.scene.selected_pipeline
-    if not pipeline:
-        return
-
-    view_orientation = rowan.from_matrix(args.viewport.viewMatrix[:, :3])
-    bod = freud.environment.BondOrder(bins, mode)
-    data = pipeline.compute(args.frame)
-    bod.compute(
-        system=data,
-        neighbors=neighbors,
-        orientations=data.particles.orientations,
-        reset=True,
-    )
-
-    view = to_view(bod, view_orientation, image_size)
-    buf = to_image(
-        view, cmap="afmhot", clip_percentile=clip_percentile, viewmode=viewmode
-    )
-    width, height, bytes_per_pixel = buf.shape
-    img = PySide6.QtGui.QImage(
-        buf,
-        width,
-        height,
-        width * bytes_per_pixel,
-        PySide6.QtGui.QImage.Format_RGBA8888,
-    )
-    # Paint QImage onto viewport canvas
-    args.painter.drawImage(draw_x, draw_y, img)

--- a/freud/overlay_BondOrder.py
+++ b/freud/overlay_BondOrder.py
@@ -37,9 +37,7 @@ class BondOrderOverlay(ViewportOverlayInterface):
         label="Image Position",
     )
 
-    def render(
-        self, canvas: ViewportOverlayInterface.Canvas, data: DataCollection, **kwargs
-    ):
+    def render(self, canvas: ViewportOverlayInterface.Canvas, data: DataCollection, **kwargs):
         bod = freud.environment.BondOrder(bins=self.bins, mode=self.mode)
         bod.compute(
             system=data,

--- a/freud/overlay_DiffractionPattern.py
+++ b/freud/overlay_DiffractionPattern.py
@@ -2,11 +2,11 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 
-import numpy as np
 import PySide6.QtGui
 import rowan
 
 import freud
+import numpy as np
 
 print("Diffraction, freud version", freud.__version__)
 

--- a/freud/overlay_PMFT.py
+++ b/freud/overlay_PMFT.py
@@ -4,13 +4,13 @@
 
 import matplotlib
 import matplotlib.pyplot as plt
-import numpy as np
 import ovito
 import PySide2.QtGui
 import rowan
 from matplotlib import patches
 
 import freud
+import numpy as np
 
 
 def get_unit_area_ngon(n):

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -1,80 +1,68 @@
 # Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-
-import matplotlib
-import matplotlib.pyplot as plt
-import PySide6.QtGui
-
 import freud
+import matplotlib.pyplot as plt
+import numpy as np
+from ovito.data import DataCollection
+from ovito.vis import ViewportOverlayInterface
+from traits.api import Bool, Enum, Range, Tuple
 
-# Activate 'agg' backend for off-screen plotting.
-matplotlib.use("Agg")
 
+class RadialDistributionOverlay(ViewportOverlayInterface):
+    # Adjustable user parameters:
+    bins = Range(value=300, low=1, label="RDF Bins", dtype=int)
+    r_max = Range(value=5.0, low=0.0, label="Maximum Radius")
+    font_scale = Range(value=2.75, low=0.0, label="Font Scale")
 
-def render(
-    args,
-    bins: int = 300,
-    r_max: float = 5.0,
-    dpi: float = 150,
-    draw_x: float = 10,
-    width: float = None,
-    height: float = None,
-    draw_y: float = 10,
-    align: str = "bottom left",
-    compute_first_shell_min: bool = False,
-):
-    plt.close()
-    pipeline = args.scene.selected_pipeline
-    if not pipeline:
-        return
-    data = pipeline.compute(args.frame)
+    output_size = Tuple((512, 384), label="Output Image Size", dtype=tuple[int, int])
 
-    rdf = freud.density.RDF(bins=bins, r_max=r_max)
-    rdf.compute(data)
-
-    # Get size of rendered viewport image in pixels.
-
-    viewport_width = args.painter.window().width()
-    viewport_height = args.painter.window().height()
-    if width is None:
-        width = viewport_width / 600
-    if height is None:
-        height = viewport_height / 800
-    if "right" in align:
-        draw_x = viewport_width - dpi * width - draw_x
-    if "bottom" in align:
-        draw_y = viewport_height - dpi * height - draw_y
-
-    # Create figure
-    fig, ax = plt.subplots(figsize=(width, height), dpi=dpi)
-    rdf.plot(ax=ax)
-
-    if compute_first_shell_min:
-        import scipy
-
-        import numpy as np
-
-        rdf_minima = scipy.signal.argrelmin(rdf.rdf)[0]
-        min_point = [rdf.bin_centers[rdf_minima[np.argmin(rdf.rdf[rdf_minima])]]]
-        plt.vlines(
-            min_point, *ax.get_ylim(), "k", "dashed", label=min_point[0].round(3)
-        )
-        plt.legend()
-        print(f"RDF_MIN: {min_point}")
-
-    plt.tight_layout()
-    fig.patch.set_alpha(0.0)
-    plt.tight_layout()
-
-    # Render figure to an in-memory buffer.
-    buf = fig.canvas.print_to_buffer()
-
-    # Create a QImage from the memory buffer
-    res_x, res_y = buf[1]
-    img = PySide6.QtGui.QImage(
-        buf[0], res_x, res_y, PySide6.QtGui.QImage.Format_RGBA8888
+    anchor = Enum(
+        ["south west", "south east", "north west", "north east"],
+        value="north east",
+        label="Image Position",
     )
 
-    # Paint QImage onto rendered viewport
-    args.painter.drawImage(draw_x, draw_y, img)
+    compute_first_shell_min = Bool(value=False, label="Compute first shell radius")
+
+    cmap = "afmhot"
+
+    def render(
+        self,
+        canvas: ViewportOverlayInterface.Canvas,
+        data: DataCollection,
+        **kwargs,
+    ):
+        rdf = freud.density.RDF(bins=self.bins, r_max=self.r_max)
+        rdf.compute(data)
+
+        image_pos = (
+            0.01 if "west" in self.anchor else 0.99,
+            0.01 if "south" in self.anchor else 0.99,
+        )
+
+        size = self.output_size / np.array(canvas.logical_size)
+
+        # Create figure
+        with canvas.mpl_figure(
+            pos=image_pos,
+            size=size,
+            anchor=self.anchor,
+            tight_layout=True,
+            font_scale=self.font_scale,
+        ) as fig:
+            ax = fig.subplots()
+            rdf.plot(ax=ax)
+            ax.set_xticks(np.arange(rdf.bin_centers[0], self.r_max + 1).astype(int))
+            ax.set_yticks([])
+
+            if self.compute_first_shell_min:
+                import scipy
+
+                rdf_minima = scipy.signal.argrelmin(rdf.rdf)[0]
+                min_point = rdf.bin_centers[rdf_minima[np.argmin(rdf.rdf[rdf_minima])]]
+                plt.vlines(
+                    [min_point], *ax.get_ylim(), "k", "dashed", label=min_point.round(3)
+                )
+                plt.legend()
+                print(f"RDF_MIN: {min_point:.6f}")

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-import freud
 import matplotlib.pyplot as plt
-import numpy as np
 from ovito.data import DataCollection
 from ovito.vis import ViewportOverlayInterface
 from traits.api import Bool, Enum, Range, Tuple
+
+import freud
+import numpy as np
 
 
 class RadialDistributionOverlay(ViewportOverlayInterface):

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -51,8 +51,9 @@ def render(
     rdf.plot(ax=ax)
 
     if compute_first_shell_min:
-        import numpy as np
         import scipy
+
+        import numpy as np
 
         rdf_minima = scipy.signal.argrelmin(rdf.rdf)[0]
         min_point = [rdf.bin_centers[rdf_minima[np.argmin(rdf.rdf[rdf_minima])]]]

--- a/freud/overlay_RDF.py
+++ b/freud/overlay_RDF.py
@@ -62,8 +62,6 @@ class RadialDistributionOverlay(ViewportOverlayInterface):
 
                 rdf_minima = scipy.signal.argrelmin(rdf.rdf)[0]
                 min_point = rdf.bin_centers[rdf_minima[np.argmin(rdf.rdf[rdf_minima])]]
-                plt.vlines(
-                    [min_point], *ax.get_ylim(), "k", "dashed", label=min_point.round(3)
-                )
+                plt.vlines([min_point], *ax.get_ylim(), "k", "dashed", label=min_point.round(3))
                 plt.legend()
                 print(f"RDF_MIN: {min_point:.6f}")

--- a/numpy/overlay_DiffractionPattern.py
+++ b/numpy/overlay_DiffractionPattern.py
@@ -1,10 +1,11 @@
 import matplotlib
-import numpy as np
 import PySide6.QtGui
 import scipy.ndimage
 from ovito.data import DataCollection
 from ovito.vis import ViewportOverlayInterface
 from traits.api import Enum, Range, String
+
+import numpy as np
 
 
 class DiffractionPatternOverlay(ViewportOverlayInterface):

--- a/numpy/overlay_DiffractionPattern.py
+++ b/numpy/overlay_DiffractionPattern.py
@@ -92,7 +92,7 @@ class DiffractionPatternOverlay(ViewportOverlayInterface):
             top = (h - zh) // 2
             left = (w - zw) // 2
             fft_image = scipy.ndimage.zoom(
-                fft_image[top:top + zh, left:left + zw], zoom_tuple, order=0
+                fft_image[top : top + zh, left : left + zw], zoom_tuple, order=0
             )
 
         width, height, bytes_per_pixel = fft_image.shape

--- a/numpy/overlay_DiffractionPattern.py
+++ b/numpy/overlay_DiffractionPattern.py
@@ -92,7 +92,7 @@ class DiffractionPatternOverlay(ViewportOverlayInterface):
             top = (h - zh) // 2
             left = (w - zw) // 2
             fft_image = scipy.ndimage.zoom(
-                fft_image[top : top + zh, left : left + zw], zoom_tuple, order=0
+                fft_image[top:top + zh, left:left + zw], zoom_tuple, order=0
             )
 
         width, height, bytes_per_pixel = fft_image.shape

--- a/numpy/overlay_DiffractionPattern.py
+++ b/numpy/overlay_DiffractionPattern.py
@@ -32,9 +32,7 @@ class DiffractionPatternOverlay(ViewportOverlayInterface):
 
     act_safe = False
 
-    def render(
-        self, canvas: ViewportOverlayInterface.Canvas, data: DataCollection, **kwargs
-    ):
+    def render(self, canvas: ViewportOverlayInterface.Canvas, data: DataCollection, **kwargs):
         print(self.output_blur_width, type(self.output_blur_width))
 
         # By default, we do not prune points "inside" the camera
@@ -44,17 +42,13 @@ class DiffractionPatternOverlay(ViewportOverlayInterface):
             xy = np.array(xy, dtype=float)
 
         except ValueError:  # One or more points lie behind the camera
-            xy = np.array(
-                [p if p is not None else [np.nan, np.nan] for p in xy], dtype=float
-            )
+            xy = np.array([p if p is not None else [np.nan, np.nan] for p in xy], dtype=float)
 
         # Create image by making a 2D histogram (copying freud)
         hist, _, _ = np.histogram2d(*xy.T, bins=self.num_bins_input)
 
         # Apply gaussian blur if desired
-        image = scipy.ndimage.gaussian_filter(
-            hist, self.input_blur_width, order=0, mode="wrap"
-        )
+        image = scipy.ndimage.gaussian_filter(hist, self.input_blur_width, order=0, mode="wrap")
 
         # Take FFT
         fft_image = np.fft.fft2(image)

--- a/numpy/overlay_DiffractionPattern.py
+++ b/numpy/overlay_DiffractionPattern.py
@@ -1,0 +1,117 @@
+import matplotlib
+import numpy as np
+import PySide6.QtGui
+import scipy.ndimage
+from ovito.data import DataCollection
+from ovito.vis import ViewportOverlayInterface
+from traits.api import Enum, Range, String
+
+
+class DiffractionPatternOverlay(ViewportOverlayInterface):
+    # Adjustable user parameters:
+    num_bins_input = Range(value=512, low=1, label="Input Image Size", dtype=int)
+    output_size = Range(value=512, low=1, label="Output Image Size", dtype=int)
+
+    input_blur_width = Range(value=0.0, low=0.0, label="σ for input blur")
+    output_blur_width = Range(value=0.0, low=0.0, label="σ for output blur")
+
+    intensity_cutoff = Range(value=0.0, low=0.0, high=1.0, label="Intensity Cutoff")
+
+    zoom = Range(value=1.0, low=0.0, label="Zoom Factor")
+
+    cmap = String(value="afmhot", label="Colormap")
+    cmap_oom_offset = Range(value=3, low=0, label="Colormap Scale Offset")
+
+    # Code image position to the anchor parameter of canvas.draw_image
+    anchor = Enum(
+        ["south west", "south east", "north west", "north east"],
+        value="south west",
+        label="Image Position",
+    )
+
+    act_safe = False
+
+    def render(
+        self, canvas: ViewportOverlayInterface.Canvas, data: DataCollection, **kwargs
+    ):
+        print(self.output_blur_width, type(self.output_blur_width))
+
+        # By default, we do not prune points "inside" the camera
+        xy = [canvas.project_location(xyz) for xyz in data.particles.positions]
+
+        try:
+            xy = np.array(xy, dtype=float)
+
+        except ValueError:  # One or more points lie behind the camera
+            xy = np.array(
+                [p if p is not None else [np.nan, np.nan] for p in xy], dtype=float
+            )
+
+        # Create image by making a 2D histogram (copying freud)
+        hist, _, _ = np.histogram2d(*xy.T, bins=self.num_bins_input)
+
+        # Apply gaussian blur if desired
+        image = scipy.ndimage.gaussian_filter(
+            hist, self.input_blur_width, order=0, mode="wrap"
+        )
+
+        # Take FFT
+        fft_image = np.fft.fft2(image)
+        fft_image = np.fft.fftshift(fft_image)
+        fft_image = np.sqrt(np.real(fft_image * np.conjugate(fft_image)))
+        if not np.isclose(self.output_blur_width, 0):
+            fft_image = scipy.ndimage.gaussian_filter(
+                fft_image, self.output_blur_width, order=0, mode="wrap"
+            )
+
+        # make image out of FFT
+        norm = matplotlib.colors.LogNorm(
+            vmin=10 ** (-np.log10(data.particles.count) + self.cmap_oom_offset),
+            vmax=data.particles.count,
+            clip=True,
+        )
+
+        cmap = matplotlib.colormaps.get_cmap(self.cmap)
+        fft_image = cmap(norm(fft_image.T))
+
+        # Resample fft_image to output_size
+        scale = self.output_size / self.num_bins_input
+
+        if not np.isclose(scale, 1):
+            resample_tuple = (scale,) * 2 + (1,) * (fft_image.ndim - 2)
+            fft_image = scipy.ndimage.zoom(fft_image, resample_tuple, order=0)
+
+        # Bounding box of the zoomed-in region within the input array
+
+        if self.zoom > 1:
+            zoom_tuple = (self.zoom, self.zoom) + (1,) * (fft_image.ndim - 2)
+            h, w = fft_image.shape[:2]
+            zh = np.ceil(h / self.zoom).astype(int)
+            zw = np.ceil(w / self.zoom).astype(int)
+            top = (h - zh) // 2
+            left = (w - zw) // 2
+            fft_image = scipy.ndimage.zoom(
+                fft_image[top : top + zh, left : left + zw], zoom_tuple, order=0
+            )
+
+        width, height, bytes_per_pixel = fft_image.shape
+        buf = (fft_image * 255).astype(np.uint8)
+
+        intensity_cutoff = (1 - self.intensity_cutoff) * 255
+        buf[np.mean(buf, axis=2) > intensity_cutoff] = 0
+
+        # Paint QImage onto viewport canvas
+        img = PySide6.QtGui.QImage(
+            buf,
+            width,
+            height,
+            canvas.preferred_qimage_format,
+        )
+
+        size_fraction = self.output_size / np.array(canvas.logical_size)
+        image_pos = (
+            0.01 if "west" in self.anchor else 0.99,
+            0.01 if "south" in self.anchor else 0.99,
+        )
+
+        canvas.draw_image(img, pos=image_pos, size=size_fraction, anchor=self.anchor)


### PR DESCRIPTION
Translated diffraction and bond order overlays to the Ovito 3.11 API, which entirely restructured how user-interactive controls and python overlays must be written. The RDF overlay has also been refactored to make use of the new ovito-matplotlib context manager

The implementation for the diffraction pattern is different from the Freud diffraction pattern, as it uses numpy in order to (1) enable diffraction for non cubic boxes and (2) perform much better, as less processing is done to the output image. This change is separate from the interface overhaul, as the pattern established here should assist in translating other overlays.

~**Waiting on CI swap to ruff (#31)**. Plan to tag tcmoore3 for review on this~